### PR TITLE
Deployment: Smithery config

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,19 @@
+# Smithery configuration file: https://smithery.ai/docs/deployments
+
+build:
+  dockerBuildPath: .
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - searxngUrl
+    properties:
+      searxngUrl:
+        type: string
+        description: The URL of the searxng server.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    (config) => ({command:'uv',args:['--project', '.', 'run', 'mcp-searxng/main.py'], env:{SEARXNG_URL: config.searxngUrl}})


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML configuration file, which specifies how to start the MCP and what configuration options it supports. This enables hosting the MCP server on [Smithery](https://smithery.ai) and allows users to connect to the hosted version over SSE without additional dependencies. You may deploy your server by visiting your [server page](https://smithery.ai/server/mcp-searxng) and claiming it.

Please review these updates to verify their accuracy for your server. Let us know if you have any questions. 🙂