### PR TITLE
fix: drop required number_of_results field removed in SearXNG 2026.5.29

### DIFF
--- a/src/mcp_searxng/search.py
+++ b/src/mcp_searxng/search.py
@@ -39,7 +39,6 @@ class Infobox(BaseModel):
 
 class Response(BaseModel):
     query: str
-    number_of_results: int
     results: list[SearchResult]
     # answers: list[str]
     # corrections: list[str]


### PR DESCRIPTION
SearXNG removed the `number_of_results` key from its JSON search API in searxng/searxng@dd27fce3b (PR #6130, released in 2026.5.29). The Response model declared it as a required int, so Response.model_validate_json() raised a ValidationError on every search against current SearXNG, even though valid results were returned.
